### PR TITLE
Allow API to Set PlayerID

### DIFF
--- a/Controllers/PlayerController.cs
+++ b/Controllers/PlayerController.cs
@@ -27,9 +27,9 @@ public class PlayerController : ControllerBase
     }
 
     [HttpPost]
-    public Player Post(int playerID,string codename)
+    public Player Post(int playerID, string codename)
     {
-        var player = new Player(playerID,codename);
+        var player = new Player(playerID, codename);
         Context.Add(player);
         Context.SaveChanges();
         return player;

--- a/Controllers/PlayerController.cs
+++ b/Controllers/PlayerController.cs
@@ -27,9 +27,9 @@ public class PlayerController : ControllerBase
     }
 
     [HttpPost]
-    public Player Post(string codename)
+    public Player Post(int playerID,string codename)
     {
-        var player = new Player(codename);
+        var player = new Player(playerID,codename);
         Context.Add(player);
         Context.SaveChanges();
         return player;

--- a/Migrations/20240215182901_rename-id-to-PlayerID-in-table-Player.Designer.cs
+++ b/Migrations/20240215182901_rename-id-to-PlayerID-in-table-Player.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using lasertech_backend.Model;
@@ -11,9 +12,11 @@ using lasertech_backend.Model;
 namespace lasertech_backend.Migrations
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20240215182901_rename-id-to-PlayerID-in-table-Player")]
+    partial class renameidtoPlayerIDintablePlayer
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20240215182901_rename-id-to-PlayerID-in-table-Player.cs
+++ b/Migrations/20240215182901_rename-id-to-PlayerID-in-table-Player.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace lasertech_backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class renameidtoPlayerIDintablePlayer : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "Id",
+                table: "players",
+                newName: "PlayerID");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "PlayerID",
+                table: "players",
+                newName: "Id");
+        }
+    }
+}

--- a/Model/Player.cs
+++ b/Model/Player.cs
@@ -4,7 +4,8 @@ namespace lasertech_backend.Model;
 
 public class Player
 {
-    public int Id { get; set; }
+    [Key]
+    public int PlayerID { get; set; }
 
     [Required(ErrorMessage = "Codename is required")]
     [MinLength(3, ErrorMessage = "Codename need to be more than 3 character")]
@@ -14,8 +15,9 @@ public class Player
     [DataType(DataType.DateTime, ErrorMessage = "Invalid datatype for LastUpdated")]
     public DateTime LastUpdated { get; set; } = DateTime.UtcNow;
 
-    public Player(string codename)
+    public Player(int playerID,string codename)
     {
+        PlayerID = playerID;
         Codename = codename;
     }
 }

--- a/Model/Player.cs
+++ b/Model/Player.cs
@@ -4,8 +4,7 @@ namespace lasertech_backend.Model;
 
 public class Player
 {
-    [Key]
-    public int PlayerID { get; set; }
+    [Key] public int PlayerID { get; set; }
 
     [Required(ErrorMessage = "Codename is required")]
     [MinLength(3, ErrorMessage = "Codename need to be more than 3 character")]
@@ -15,7 +14,7 @@ public class Player
     [DataType(DataType.DateTime, ErrorMessage = "Invalid datatype for LastUpdated")]
     public DateTime LastUpdated { get; set; } = DateTime.UtcNow;
 
-    public Player(int playerID,string codename)
+    public Player(int playerID, string codename)
     {
         PlayerID = playerID;
         Codename = codename;

--- a/Program.cs
+++ b/Program.cs
@@ -20,7 +20,6 @@ builder.Services.AddCors(options =>
     });
 });
 
-
 int udpPort = 7500;
 
 var udpListenerService = new UdpListenerService(udpPort);


### PR DESCRIPTION
### Summary
This PR update the player structure to allow API to set PlayerID in the Player class

### Details
In order to allow our API to set PlayerID, we modified the Controller to accept PlayerID as one of the parameter and enforced the primary key constraint in the model to enforce PlayerID uniqueness. 

### Design Decision
Originally PlayerID is auto generated and auto-incremented. This change allow more efficient player look up by checking for an exact integer match. Searching by codename can be probablematic because player might not enter their name correctly, Using fuzzy match will be extremely inefficient as our system scale.  

### How to Test this PR

1. Launch the application and navigate to the home page to access Swagger Web App 
2. Send a POST request to onboard a new player by entering a codename and a PlayerID and clicking 'Execute'

![image](https://github.com/QuantumRangers-SE-Team-10/lasertech-backend/assets/76791231/a1d905d6-6fd1-45c8-a565-a81b5a0e5d11)

3. If successful, you should the response object should show the correct player information in the server response message.
![image](https://github.com/QuantumRangers-SE-Team-10/lasertech-backend/assets/76791231/629211b5-f5fd-48b7-88a1-3b33bec8826c)


### Checks
- [x] I have tested my code on a different machine and confirmed that it works as expected.
- [x] Reviewer - I have cloned the branch, tested it, and ensured that it works as expected.

