### PR TITLE
Implement Game and PlayerSession Models with Associated API Controllers

### DIFF
--- a/Controllers/GameController.cs
+++ b/Controllers/GameController.cs
@@ -8,7 +8,6 @@ namespace lasertech_backend.Controllers;
 public class GameController : ControllerBase
 {
     private readonly GameContext Context;
-
     public GameController(GameContext context)
     {
         this.Context = context;
@@ -31,6 +30,15 @@ public class GameController : ControllerBase
     {
         var game = new Game();
         Context.Add(game);
+        Context.SaveChanges();
+        return game;
+    }
+    
+    [HttpPost("{gameID}")]
+    public Game Post(int gameID,PlayerSession playerSession)
+    {
+        var game = Context.games.Find(gameID)!;
+        game.AddPlayerSessionTable(playerSession);
         Context.SaveChanges();
         return game;
     }

--- a/Controllers/GameController.cs
+++ b/Controllers/GameController.cs
@@ -3,17 +3,19 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace lasertech_backend.Controllers;
 
+
+
 [Route("api/[controller]")]
 [ApiController]
-public class PlayerController : ControllerBase
+public class GameController: ControllerBase
 {
     private readonly GameContext Context;
 
-    public PlayerController(GameContext context)
+    public GameController(GameContext context)
     {
         this.Context = context;
     }
-
+  
     [HttpGet]
     public List<Player> Get()
     {
@@ -34,14 +36,5 @@ public class PlayerController : ControllerBase
         Context.SaveChanges();
         return player;
     }
-
-    [HttpPut("{playerID}")]
-    public Player Put(int playerID, string newCodename)
-    {
-        var player = Context.players.Find(playerID)!;
-        player.Codename = newCodename;
-        player.LastUpdated = DateTime.UtcNow;
-        Context.SaveChanges();
-        return player;
-    }
+    
 }

--- a/Controllers/GameController.cs
+++ b/Controllers/GameController.cs
@@ -3,11 +3,9 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace lasertech_backend.Controllers;
 
-
-
 [Route("api/[controller]")]
 [ApiController]
-public class GameController: ControllerBase
+public class GameController : ControllerBase
 {
     private readonly GameContext Context;
 
@@ -15,26 +13,25 @@ public class GameController: ControllerBase
     {
         this.Context = context;
     }
-  
+
     [HttpGet]
-    public List<Player> Get()
+    public List<Game> Get()
     {
-        return Context.players.ToList();
+        return Context.games.ToList();
     }
 
-    [HttpGet("{playerID}")]
-    public Player Get(int playerID)
+    [HttpGet("{gameID}")]
+    public Game Get(int gameID)
     {
-        return Context.players.Find(playerID)!;
+        return Context.games.Find(gameID)!;
     }
 
     [HttpPost]
-    public Player Post(int playerID, string codename)
+    public Game Post()
     {
-        var player = new Player(playerID, codename);
-        Context.Add(player);
+        var game = new Game();
+        Context.Add(game);
         Context.SaveChanges();
-        return player;
+        return game;
     }
-    
 }

--- a/Controllers/GameController.cs
+++ b/Controllers/GameController.cs
@@ -1,5 +1,7 @@
+using lasertech_backend.DTOs;
 using lasertech_backend.Model;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace lasertech_backend.Controllers;
 
@@ -8,38 +10,34 @@ namespace lasertech_backend.Controllers;
 public class GameController : ControllerBase
 {
     private readonly GameContext Context;
+
     public GameController(GameContext context)
     {
         this.Context = context;
     }
 
     [HttpGet]
-    public List<Game> Get()
+    public async Task<ActionResult<List<Game>>> Get()
     {
-        return Context.games.ToList();
+        var games = await Context.games.ToListAsync();
+        return Ok(games);
     }
 
     [HttpGet("{gameID}")]
-    public Game Get(int gameID)
+    public async Task<ActionResult<Game>> Get(int gameID)
     {
-        return Context.games.Find(gameID)!;
+        var game = await Context.games
+            .Include(g => g.PlayerSessions)
+            .FirstOrDefaultAsync(g => g.GameID == gameID);
+        return Ok(game);
     }
 
     [HttpPost]
-    public Game Post()
+    public async Task<ActionResult<Game>> Post()
     {
         var game = new Game();
         Context.Add(game);
-        Context.SaveChanges();
-        return game;
-    }
-    
-    [HttpPost("{gameID}")]
-    public Game Post(int gameID,PlayerSession playerSession)
-    {
-        var game = Context.games.Find(gameID)!;
-        game.AddPlayerSessionTable(playerSession);
-        Context.SaveChanges();
+        await Context.SaveChangesAsync();
         return game;
     }
 }

--- a/Controllers/PlayerController.cs
+++ b/Controllers/PlayerController.cs
@@ -1,5 +1,6 @@
 using lasertech_backend.Model;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace lasertech_backend.Controllers;
 
@@ -15,33 +16,34 @@ public class PlayerController : ControllerBase
     }
 
     [HttpGet]
-    public List<Player> Get()
+    public async Task<ActionResult<List<Player>>> Get()
     {
-        return Context.players.ToList();
+        var player = await Context.players.ToListAsync();
+        return Ok(player);
     }
 
     [HttpGet("{playerID}")]
-    public Player Get(int playerID)
+    public async Task<ActionResult<Player>> Get(int playerID)
     {
-        return Context.players.Find(playerID)!;
+        var player = await Context.players.FindAsync(playerID);
+        return Ok(player);
     }
 
     [HttpPost]
-    public Player Post(int playerID, string codename)
+    public async Task<ActionResult<Player>> Post([FromBody] Player player)
     {
-        var player = new Player(playerID, codename);
         Context.Add(player);
-        Context.SaveChanges();
-        return player;
+        await Context.SaveChangesAsync();
+        return Ok(player);
     }
 
     [HttpPut("{playerID}")]
-    public Player Put(int playerID, string newCodename)
+    public async Task<ActionResult> Put(int playerID, [FromBody] string newCodename)
     {
-        var player = Context.players.Find(playerID)!;
+        var player = await Context.players.FindAsync(playerID);
         player.Codename = newCodename;
         player.LastUpdated = DateTime.UtcNow;
-        Context.SaveChanges();
-        return player;
+        await Context.SaveChangesAsync();
+        return NoContent();
     }
 }

--- a/Controllers/PlayerSessionController.cs
+++ b/Controllers/PlayerSessionController.cs
@@ -1,0 +1,25 @@
+using lasertech_backend.DTOs;
+using lasertech_backend.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace lasertech_backend.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class PlayerSessionController : ControllerBase
+{
+    private readonly GameContext Context;
+
+    public PlayerSessionController(GameContext context)
+    {
+        this.Context = context;
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<PlayerSession>> Post(PlayerSession playerSession)
+    {
+        Context.Add(playerSession);
+        await Context.SaveChangesAsync();
+        return Ok(playerSession);
+    }
+}

--- a/DTOs/PlayerSessionDTO.cs
+++ b/DTOs/PlayerSessionDTO.cs
@@ -1,0 +1,11 @@
+using lasertech_backend.Enum;
+
+namespace lasertech_backend.DTOs;
+
+public class PlayerSessionDTO
+{
+    public int PlayerID { get; set; }
+    public int PlayerScore { get; set; }
+    public TeamSide Team { get; set; }
+    public int EquipmentID { get; set; }
+}

--- a/Data/GameContext.cs
+++ b/Data/GameContext.cs
@@ -10,4 +10,5 @@ public class GameContext : DbContext
 
     public DbSet<Player> players { set; get; }
     public DbSet<Game> games { set; get; }
+    public DbSet<PlayerSession> playerSessions { set; get; }
 }

--- a/Data/GameContext.cs
+++ b/Data/GameContext.cs
@@ -9,4 +9,5 @@ public class GameContext : DbContext
     }
 
     public DbSet<Player> players { set; get; }
+    public DbSet<Game> games { set; get; }
 }

--- a/Enum/TeamSide.cs
+++ b/Enum/TeamSide.cs
@@ -1,0 +1,7 @@
+namespace lasertech_backend.Enum;
+
+public enum TeamSide
+{
+    Red,
+    Blue
+}

--- a/Migrations/20240219194406_AddGameTable.Designer.cs
+++ b/Migrations/20240219194406_AddGameTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using lasertech_backend.Model;
@@ -11,9 +12,11 @@ using lasertech_backend.Model;
 namespace lasertech_backend.Migrations
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20240219194406_AddGameTable")]
+    partial class AddGameTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -21,25 +24,6 @@ namespace lasertech_backend.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
-
-            modelBuilder.Entity("lasertech_backend.Model.Game", b =>
-                {
-                    b.Property<int>("GameID")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("GameID"));
-
-                    b.Property<int>("BlueScore")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("RedScore")
-                        .HasColumnType("integer");
-
-                    b.HasKey("GameID");
-
-                    b.ToTable("games");
-                });
 
             modelBuilder.Entity("lasertech_backend.Model.Player", b =>
                 {

--- a/Migrations/20240219194406_AddGameTable.cs
+++ b/Migrations/20240219194406_AddGameTable.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace lasertech_backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGameTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/Migrations/20240219202632_CreateGameTable.Designer.cs
+++ b/Migrations/20240219202632_CreateGameTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using lasertech_backend.Model;
@@ -11,9 +12,11 @@ using lasertech_backend.Model;
 namespace lasertech_backend.Migrations
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20240219202632_CreateGameTable")]
+    partial class CreateGameTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20240219202632_CreateGameTable.cs
+++ b/Migrations/20240219202632_CreateGameTable.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace lasertech_backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class CreateGameTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "games",
+                columns: table => new
+                {
+                    GameID = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    RedScore = table.Column<int>(type: "integer", nullable: false),
+                    BlueScore = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_games", x => x.GameID);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "games");
+        }
+    }
+}

--- a/Migrations/20240219231140_AddPlayerSessionTable.Designer.cs
+++ b/Migrations/20240219231140_AddPlayerSessionTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using lasertech_backend.Model;
@@ -11,9 +12,11 @@ using lasertech_backend.Model;
 namespace lasertech_backend.Migrations
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20240219231140_AddPlayerSessionTable")]
+    partial class AddPlayerSessionTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20240219231140_AddPlayerSessionTable.cs
+++ b/Migrations/20240219231140_AddPlayerSessionTable.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace lasertech_backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPlayerSessionTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "playerSessions",
+                columns: table => new
+                {
+                    PlayerSessionID = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    GameID = table.Column<int>(type: "integer", nullable: false),
+                    PlayerID = table.Column<int>(type: "integer", nullable: false),
+                    PlayerScore = table.Column<int>(type: "integer", nullable: false),
+                    Team = table.Column<int>(type: "integer", nullable: false),
+                    EquipmentID = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_playerSessions", x => x.PlayerSessionID);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "playerSessions");
+        }
+    }
+}

--- a/Migrations/20240220013902_AddRelationToPlayerSessionAndGameTable.Designer.cs
+++ b/Migrations/20240220013902_AddRelationToPlayerSessionAndGameTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using lasertech_backend.Model;
@@ -11,9 +12,11 @@ using lasertech_backend.Model;
 namespace lasertech_backend.Migrations
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20240220013902_AddRelationToPlayerSessionAndGameTable")]
+    partial class AddRelationToPlayerSessionAndGameTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20240220013902_AddRelationToPlayerSessionAndGameTable.cs
+++ b/Migrations/20240220013902_AddRelationToPlayerSessionAndGameTable.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace lasertech_backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRelationToPlayerSessionAndGameTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_playerSessions_GameID",
+                table: "playerSessions",
+                column: "GameID");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_playerSessions_PlayerID",
+                table: "playerSessions",
+                column: "PlayerID");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_playerSessions_games_GameID",
+                table: "playerSessions",
+                column: "GameID",
+                principalTable: "games",
+                principalColumn: "GameID",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_playerSessions_players_PlayerID",
+                table: "playerSessions",
+                column: "PlayerID",
+                principalTable: "players",
+                principalColumn: "PlayerID",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_playerSessions_games_GameID",
+                table: "playerSessions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_playerSessions_players_PlayerID",
+                table: "playerSessions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_playerSessions_GameID",
+                table: "playerSessions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_playerSessions_PlayerID",
+                table: "playerSessions");
+        }
+    }
+}

--- a/Model/Game.cs
+++ b/Model/Game.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using lasertech_backend.Migrations;
 
 namespace lasertech_backend.Model;
 
@@ -7,10 +8,17 @@ public class Game
     [Key] public int GameID { get; set; }
     public int RedScore { get; set; }
     public int BlueScore { get; set; }
+    public virtual ICollection<PlayerSession> PlayerSessions { get; set; } // one-to-many
 
     public Game()
     {
         BlueScore = 0;
         RedScore = 0;
+        PlayerSessions = new List<PlayerSession>();
+    }
+
+    public void AddPlayerSessionTable(PlayerSession playerSession)
+    {
+        PlayerSessions.Append(playerSession);
     }
 }

--- a/Model/Game.cs
+++ b/Model/Game.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using lasertech_backend.DTOs;
 using lasertech_backend.Migrations;
 
 namespace lasertech_backend.Model;
@@ -15,10 +16,5 @@ public class Game
         BlueScore = 0;
         RedScore = 0;
         PlayerSessions = new List<PlayerSession>();
-    }
-
-    public void AddPlayerSessionTable(PlayerSession playerSession)
-    {
-        PlayerSessions.Append(playerSession);
     }
 }

--- a/Model/Game.cs
+++ b/Model/Game.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace lasertech_backend.Model;
+
+public class Game
+{
+    [Key] public int GameID { get; set; }
+    public int RedScore { get; set; }
+    public int BlueScore { get; set; }
+
+    public Game()
+    {
+        BlueScore = 0;
+        RedScore = 0;
+    }
+}

--- a/Model/PlayerSession.cs
+++ b/Model/PlayerSession.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using lasertech_backend.Enum;
+
+namespace lasertech_backend.Model;
+
+public class PlayerSession
+{
+    [Key]
+    public int PlayerSessionID { get; set; }
+    public int GameID { get; set; }
+    public int PlayerID { get; set; }
+    public int PlayerScore { get; set; }
+    public TeamSide Team { get; set; }
+    public int EquipmentID { get; set; }
+
+    public PlayerSession(int gameID, int playerID, TeamSide team, int equipmentID)
+    {
+        GameID = gameID;
+        PlayerID = playerID;
+        Team = team;
+        PlayerScore = 0;
+        EquipmentID = equipmentID;
+    }
+}

--- a/Model/PlayerSession.cs
+++ b/Model/PlayerSession.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using lasertech_backend.Enum;
 
 namespace lasertech_backend.Model;
@@ -7,12 +8,19 @@ public class PlayerSession
 {
     [Key]
     public int PlayerSessionID { get; set; }
+    
+    [ForeignKey("Game")]
     public int GameID { get; set; }
+    private Game Game { get; set; }
+    
+    [ForeignKey("Player")]
     public int PlayerID { get; set; }
+
+    private Player Player { get; set; }
     public int PlayerScore { get; set; }
     public TeamSide Team { get; set; }
     public int EquipmentID { get; set; }
-
+    
     public PlayerSession(int gameID, int playerID, TeamSide team, int equipmentID)
     {
         GameID = gameID;

--- a/Model/PlayerSession.cs
+++ b/Model/PlayerSession.cs
@@ -1,26 +1,24 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using lasertech_backend.DTOs;
 using lasertech_backend.Enum;
 
 namespace lasertech_backend.Model;
 
 public class PlayerSession
 {
-    [Key]
-    public int PlayerSessionID { get; set; }
-    
-    [ForeignKey("Game")]
-    public int GameID { get; set; }
+    [Key] public int PlayerSessionID { get; set; }
+
+    [ForeignKey("Game")] public int GameID { get; set; }
     private Game Game { get; set; }
-    
-    [ForeignKey("Player")]
-    public int PlayerID { get; set; }
+
+    [ForeignKey("Player")] public int PlayerID { get; set; }
 
     private Player Player { get; set; }
     public int PlayerScore { get; set; }
     public TeamSide Team { get; set; }
     public int EquipmentID { get; set; }
-    
+
     public PlayerSession(int gameID, int playerID, TeamSide team, int equipmentID)
     {
         GameID = gameID;

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # lasertech-backend
 
 info
+
+edit read me to test amend

--- a/lasertech-backend.csproj
+++ b/lasertech-backend.csproj
@@ -22,4 +22,8 @@
       <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="DTO\" />
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
### Summary
Extend Database with Game and PlayerSession Entities & Introduce Related API Controllers.

### Details
We start by adding two additional table to the database. The Game table keeps track of the red and blue team score along with an auto incrementing GameID field. The second table is the PlayerSession table, this table keep track of each player session per game. The fields for the PlayerSession table includes the PlayerID, GameID, Team which determine if they are on red or blue team, Score which is the player score for that session, EquipmentID. The Game table have a one to many relationship to the PlayerSession, because each game can have up to 30 players, 30 player session will be link to the same Game entry, the equi join will be on GameID. The PlayerSession have a one to one relationship with the Game table and the Player table joining both via GameID and PlayerID respectively. 

Next I worked on the controller, I created two separate controller. One named GameController which create the API endpoint need to initialize a new game session, retrieve all game session or retrieve a single game session by id. The second controller, PlayerSession controller allow the operator to add a new player to an existing game session.  

### Design Decision


### References
[EXAMPLE - W3 School guide on photo grid](https://www.w3schools.com/howto/tryit.asp?filename=tryhow_css_image_grid_responsive)

### Checks
- [ ] I have tested my code on a different machine and confirmed that it works as expected.
- [ ] Reviewer - I have cloned the branch, tested it, and ensured that it works as expected.

