### PR TITLE
update udp broadcast address to 192.168.1.255

### DIFF
--- a/Data/GameContext.cs
+++ b/Data/GameContext.cs
@@ -7,7 +7,7 @@ public class GameContext : DbContext
     public GameContext(DbContextOptions<GameContext> options) : base(options)
     {
     }
-
+    
     public DbSet<Player> players { set; get; }
     public DbSet<Game> games { set; get; }
     public DbSet<PlayerSession> playerSessions { set; get; }

--- a/Service/GameUdpService.cs
+++ b/Service/GameUdpService.cs
@@ -41,7 +41,7 @@ public class GameUdpService : IUdpService
             foreach (var equipmentID in this.equipmentIDs)
             {
                 byte[] bytes = Encoding.ASCII.GetBytes(equipmentID);
-                await udpClient.SendAsync(bytes, bytes.Length, "127.0.0.1", transmitPort);
+                await udpClient.SendAsync(bytes, bytes.Length, "192.168.1.255", transmitPort);
             }
         }
     }


### PR DESCRIPTION
### Summary
Update Udp broadcast address to 192.168.1.255

### Details
This will allow our program to use the broadcast address to send udp packets to all local device on that subnet. 

### Design Decision
To Efficiently broadcast to all local devices on that subnet we decided to use the broadcast address instead of the limited broadcast address because we don't want our message to go to all of the devices on the local area network, just the one in the current subnet. 

### References
[LAN, WAN, SUBNET - EXPLAINED](https://www.youtube.com/watch?v=NyZWSvSj8ek)

### Checks
- [x] I have tested my code on a different machine and confirmed that it works as expected.
- [ ] Reviewer - I have cloned the branch, tested it, and ensured that it works as expected.

